### PR TITLE
Add Two New User Scripts

### DIFF
--- a/src/scripts/user_script_locals_yellow_team.lua
+++ b/src/scripts/user_script_locals_yellow_team.lua
@@ -1,0 +1,107 @@
+--
+-- LocalsYellowTeamScript by Rayman1103
+-- Description: Makes the locals team have yellow CP and unit icons.
+--
+
+gLocalsYellowTeamScriptHasLocals = false
+gLocalsYellowTeamScriptInPostLoad = false
+gLocalsYellowTeamScriptLocalsTeams = {}
+gLocalsYellowTeamScriptTeam = { [1] = {}, [2] = {} }
+
+--attempt to take control of (or listen to the calls of) the ScriptPostLoad function
+if ScriptPostLoad and not LocalsYellowTeamScript_ScriptPostLoad then
+	--backup the current ScriptPostLoad function
+	LocalsYellowTeamScript_ScriptPostLoad = ScriptPostLoad
+
+	--this is our new ScriptPostLoad function
+	ScriptPostLoad = function(...)
+		gLocalsYellowTeamScriptInPostLoad = true
+		-- let the original function happen and catch the return value
+		local LocalsYellowTeamScript_SPLreturn = {LocalsYellowTeamScript_ScriptPostLoad(unpack(arg))}
+		
+		SetTeamAsEnemy = LocalsYellowTeamScript_SetTeamAsEnemy
+		SetTeamAsFriend = LocalsYellowTeamScript_SetTeamAsFriend
+		SetTeamName = LocalsYellowTeamScript_SetTeamName
+		
+		if gLocalsYellowTeamScriptHasLocals then
+			for i, team in pairs(gLocalsYellowTeamScriptLocalsTeams) do
+				for u = 1, 2, 1 do
+					if gLocalsYellowTeamScriptTeam[u][team] == "friend" then
+						SetTeamAsFriend(u, team)
+					else
+						SetTeamAsEnemy(u, team)
+					end
+				end
+			end
+		end
+		
+		-- return the unmanipulated values
+		return unpack(LocalsYellowTeamScript_SPLreturn)
+	end
+end
+
+--attempt to take control of (or listen to the calls of) the SetTeamAsEnemy function
+if SetTeamAsEnemy and not LocalsYellowTeamScript_SetTeamAsEnemy then
+	--backup the current SetTeamAsEnemy function
+	LocalsYellowTeamScript_SetTeamAsEnemy = SetTeamAsEnemy
+
+	--this is our new SetTeamAsEnemy function
+	SetTeamAsEnemy = function(teamPtr1, teamPtr2, ...)
+		-- let the original function happen and catch the return value
+		local LocalsYellowTeamScript_STAEreturn = {LocalsYellowTeamScript_SetTeamAsEnemy(teamPtr1, teamPtr2, unpack(arg))}
+		
+		if teamPtr1 < 3 and teamPtr2 > 2 then
+			gLocalsYellowTeamScriptTeam[teamPtr1][teamPtr2] = "enemy"
+			if not gLocalsYellowTeamScriptInPostLoad and GetTeamFactionId(teamPtr2) == 5 then
+				SetTeamAsNeutral(teamPtr1, teamPtr2)
+			end
+		end
+		
+		-- return the unmanipulated values
+		return unpack(LocalsYellowTeamScript_STAEreturn)
+	end
+end
+
+--attempt to take control of (or listen to the calls of) the SetTeamAsFriend function
+if SetTeamAsFriend and not LocalsYellowTeamScript_SetTeamAsFriend then
+	--backup the current SetTeamAsFriend function
+	LocalsYellowTeamScript_SetTeamAsFriend = SetTeamAsFriend
+
+	--this is our new SetTeamAsFriend function
+	SetTeamAsFriend = function(teamPtr1, teamPtr2, ...)
+		-- let the original function happen and catch the return value
+		local LocalsYellowTeamScript_STAEreturn = {LocalsYellowTeamScript_SetTeamAsFriend(teamPtr1, teamPtr2, unpack(arg))}
+		
+		if teamPtr1 < 3 and teamPtr2 > 2 then
+			gLocalsYellowTeamScriptTeam[teamPtr1][teamPtr2] = "friend"
+			if not gLocalsYellowTeamScriptInPostLoad and GetTeamFactionId(teamPtr2) == 5 then
+				SetTeamAsNeutral(teamPtr1, teamPtr2)
+			end
+		end
+		
+		-- return the unmanipulated values
+		return unpack(LocalsYellowTeamScript_STAEreturn)
+	end
+end
+
+--attempt to take control of (or listen to the calls of) the SetTeamName function
+if SetTeamName and not LocalsYellowTeamScript_SetTeamName then
+	--backup the current SetTeamName function
+	LocalsYellowTeamScript_SetTeamName = SetTeamName
+
+	--this is our new SetTeamName function
+	SetTeamName = function(teamPtr, teamName, ...)
+		-- let the original function happen and catch the return value
+		local LocalsYellowTeamScript_STNreturn = {LocalsYellowTeamScript_SetTeamName(teamPtr, teamName, unpack(arg))}
+		
+		if teamPtr > 2 and GetTeamFactionId(teamPtr) == 5 then
+			gLocalsYellowTeamScriptHasLocals = true
+			table.insert(gLocalsYellowTeamScriptLocalsTeams, teamPtr)
+			SetTeamAsNeutral(1, teamPtr)
+			SetTeamAsNeutral(2, teamPtr)
+		end
+		
+		-- return the unmanipulated values
+		return unpack(LocalsYellowTeamScript_STNreturn)
+	end
+end

--- a/src/scripts/user_script_locals_yellow_team.lua
+++ b/src/scripts/user_script_locals_yellow_team.lua
@@ -11,7 +11,7 @@ gLocalsYellowTeamScriptTeam = { [1] = {}, [2] = {} }
 --attempt to take control of (or listen to the calls of) the ScriptPostLoad function
 if ScriptPostLoad and not LocalsYellowTeamScript_ScriptPostLoad then
 	--backup the current ScriptPostLoad function
-	LocalsYellowTeamScript_ScriptPostLoad = ScriptPostLoad
+	local LocalsYellowTeamScript_ScriptPostLoad = ScriptPostLoad
 
 	--this is our new ScriptPostLoad function
 	ScriptPostLoad = function(...)

--- a/src/scripts/user_script_rhenvar2_cp_fix.lua
+++ b/src/scripts/user_script_rhenvar2_cp_fix.lua
@@ -1,0 +1,29 @@
+--
+-- RhenVar2CPFix by Rayman1103
+-- Description: Fixes issue where Command Posts 1 and 4 aren't counted as valid CPs for Rhen Var Citadel Conquest.
+--
+
+--attempt to take control of (or listen to the calls of) the ScriptPostLoad function
+if ScriptPostLoad and not RhenVar2CPFix_ScriptPostLoad then
+	--backup the current ScriptPostLoad function
+	RhenVar2CPFix_ScriptPostLoad = ScriptPostLoad
+
+	--this is our new ScriptPostLoad function
+	ScriptPostLoad = function(...)
+		-- let the original function happen and catch the return value
+		local RhenVar2CPFix_SPLreturn = {RhenVar2CPFix_ScriptPostLoad(unpack(arg))}
+		
+		if __thisMapsCode__ == "rhn" and __thisMapsMode__ == "rhenvar2_conquest" then
+			if cp6 == nil then
+				cp6 = CommandPost:New{name = "CP1"}
+				cp7 = CommandPost:New{name = "CP4"}
+				conquest:AddCommandPost(cp6)
+				conquest:AddCommandPost(cp7)
+				conquest:Start()
+			end
+		end
+		
+		-- return the unmanipulated values
+		return unpack(RhenVar2CPFix_SPLreturn)
+	end
+end

--- a/src/scripts/user_script_rhenvar2_cp_fix.lua
+++ b/src/scripts/user_script_rhenvar2_cp_fix.lua
@@ -6,14 +6,16 @@
 --attempt to take control of (or listen to the calls of) the ScriptPostLoad function
 if ScriptPostLoad and not RhenVar2CPFix_ScriptPostLoad then
 	--backup the current ScriptPostLoad function
-	RhenVar2CPFix_ScriptPostLoad = ScriptPostLoad
+	local RhenVar2CPFix_ScriptPostLoad = ScriptPostLoad
 
 	--this is our new ScriptPostLoad function
 	ScriptPostLoad = function(...)
 		-- let the original function happen and catch the return value
 		local RhenVar2CPFix_SPLreturn = {RhenVar2CPFix_ScriptPostLoad(unpack(arg))}
 		
-		if __thisMapsCode__ == "rhn" and __thisMapsMode__ == "rhenvar2_conquest" then
+		--check if the map's Rhen Var Citadel and if the Conquest objective is defined
+		if GetWorldFilename() == "rhenvar2" and ObjectiveConquest ~= nil then
+			--if cp6 is undefined, add the missing CPs
 			if cp6 == nil then
 				cp6 = CommandPost:New{name = "CP1"}
 				cp7 = CommandPost:New{name = "CP4"}


### PR DESCRIPTION
- Add user_script_locals_yellow_team, which makes the natives on a planet use their yellow color for units and CPs.
- Add user_script_rhenvar2_cp_fix, which fixes the issue where CPs 1 and 4 aren't counted as valid CPs for Conquest mode.